### PR TITLE
META_SUBSCRIBE

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/salesforce/SalesforceSourceTask.java
@@ -180,6 +180,20 @@ public class SalesforceSourceTask extends SourceTask {
           Long sourceOffset = (Long) partitionOffset.get("replayId");
           log.info("PushTopic {} - found stored offset {}", config.salesForcePushTopicName, sourceOffset);
           replay.put(channel, sourceOffset);
+        } else {
+          replay.put(channel, -1L);
+        }
+      }
+    });
+
+    this.streamingClient.getChannel(Channel.META_SUBSCRIBE).addListener(new ClientSessionChannel.MessageListener() {
+      @Override
+      public void onMessage(ClientSessionChannel clientSessionChannel, Message message) {
+        log.info("onMessage(META_SUBSCRIBE) - {}", message);
+        if (message.isSuccessful()) {
+          log.info("onMessage(META_SUBSCRIBE) - Subscribing to {}", channel);
+        } else {
+          log.error("Error during subscribe: {} {}", message.get("error"), message.get("exception"));
         }
       }
     });


### PR DESCRIPTION
Added a subscription to meta channel META_SUBSCRIBE with logs. This helped me to see that there was an error in subscription, because replay id was not found in channel. It may be helpfull for someone else.

Also forced replay id to -1 when not found. -1 means to start to consume all new notifications.